### PR TITLE
feat: handle refetch when tab not focus

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,11 +3,14 @@ import ReactDOM from "react-dom";
 import App from "@/App";
 import { BrowserRouter } from "react-router-dom";
 import { ChakraProvider } from "@chakra-ui/react";
+import { Provider } from "@/utils/query/Query.context";
 
 ReactDOM.render(
   <BrowserRouter>
     <ChakraProvider>
-      <App />
+      <Provider>
+        <App />
+      </Provider>
     </ChakraProvider>
   </BrowserRouter>,
   document.getElementById("root")

--- a/src/utils/query/Query.tsx
+++ b/src/utils/query/Query.tsx
@@ -38,11 +38,15 @@ export const useQuery = <T,>(
   }, [dispatch]);
 
   React.useEffect(() => {
-    document.addEventListener("visibilitychange", () => {
+    const refetchWhenVisible = () => {
       if (document.visibilityState === "visible") {
         refetch();
       }
-    });
+    };
+    document.addEventListener("visibilitychange", refetchWhenVisible);
+    return () => {
+      document.addEventListener("visibilitychange", refetchWhenVisible);
+    };
   }, [refetch]);
 
   return { state, refetch };

--- a/src/utils/query/Query.tsx
+++ b/src/utils/query/Query.tsx
@@ -37,11 +37,13 @@ export const useQuery = <T,>(
     dispatch({ tag: "fetch" });
   }, [dispatch]);
 
-  document.addEventListener("visibilitychange", () => {
-    if (document.visibilityState === "visible") {
-      refetch();
-    }
-  });
+  React.useEffect(() => {
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "visible") {
+        refetch();
+      }
+    });
+  }, [refetch]);
 
   return { state, refetch };
 };

--- a/src/utils/query/Query.tsx
+++ b/src/utils/query/Query.tsx
@@ -37,5 +37,11 @@ export const useQuery = <T,>(
     dispatch({ tag: "fetch" });
   }, [dispatch]);
 
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") {
+      refetch();
+    }
+  });
+
   return { state, refetch };
 };


### PR DESCRIPTION
## Background Summary

We want to keep the data is always updated, so we should have some mechanism to do it. One of the things that we can do is that doing refetch when the tab is not focused. This actually a little bit similar like React Query feature.